### PR TITLE
Retina Macbookの外部ディスプレイでサイズがバグる時あるのを修正

### DIFF
--- a/Yabumi/script
+++ b/Yabumi/script
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'net/https'
+require 'yaml'
 
 # capture png file
 tmpfile = "/tmp/image_upload#{$$}"
@@ -16,12 +17,17 @@ if imagefile && File.exist?(imagefile) then
 else
   system "screencapture -i \"#{tmpfile}\""
   if File.exist?(tmpfile) then
-    system "sips -d profile --deleteColorManagementProperties \"#{tmpfile}\""  
     dpiWidth    = `sips -g dpiWidth "#{tmpfile}" | awk '/:/ {print $2}'`
     dpiHeight   = `sips -g dpiHeight "#{tmpfile}" | awk '/:/ {print $2}'`
     pixelWidth  = `sips -g pixelWidth "#{tmpfile}" | awk '/:/ {print $2}'`
     pixelHeight = `sips -g pixelHeight "#{tmpfile}" | awk '/:/ {print $2}'`
-    if (dpiWidth.to_f > 72.0 and dpiHeight.to_f > 72.0) then
+    displayName = `sips -g profile "#{tmpfile}" | awk -F':' '/:/ {print $2}'`.strip
+
+    displayProfile  = YAML.load(`system_profiler SPDisplaysDataType`).values[0].values[0]["Displays"]["#{displayName}"]
+    isRetinaDisplay = (displayProfile && displayProfile["Retina"] == true)
+
+    system "sips -d profile --deleteColorManagementProperties \"#{tmpfile}\""
+    if (dpiWidth.to_f > 72.0 and dpiHeight.to_f > 72.0 and isRetinaDisplay) then
         width  =  pixelWidth.to_f * 72.0 / dpiWidth.to_f
         height =  pixelHeight.to_f* 72.0 / dpiHeight.to_f
         system "sips -s dpiWidth 72 -s dpiHeight 72 -z #{height} #{width} \"#{tmpfile}\""


### PR DESCRIPTION
しばらく前に言ってた、Macbook Retina の外部ディスプレイ(Not Retina)でウィンドウキャプチャ撮ると、Retina扱いになって縮小されてしまうの直してみました。
数日私の環境(Macbook Pro Retina + MacOS 10.8.5 + 外部ディスプレイ)で使ってましたが今の所特に変なことにはなってないですが、他の色々な環境でちゃんと動くのか……?

あと現在気になっているのが、2つほどあります。
1つ目が、同じディスプレイ2台で片方 Retina / 片方 Not Retina で使用した時に区別してディスプレイ情報取得できるのか。
2つ目が、現在1つめのGPU決め打ちでやってるけど、Mac Pro とかで GPU 複数枚積んでる時にどうなるのか。
な感じです。
