### PR TITLE
Macbook Pro 15inch Retinaで動かないのを修正

### DIFF
--- a/Yabumi/script
+++ b/Yabumi/script
@@ -23,7 +23,12 @@ else
     pixelHeight = `sips -g pixelHeight "#{tmpfile}" | awk '/:/ {print $2}'`
     displayName = `sips -g profile "#{tmpfile}" | awk -F':' '/:/ {print $2}'`.strip
 
-    displayProfile  = YAML.load(`system_profiler SPDisplaysDataType`).values[0].values[0]["Displays"]["#{displayName}"]
+    displayProfile = nil
+    YAML.load(`system_profiler SPDisplaysDataType`)["Graphics/Displays"].each do |key, display|
+      if display["Displays"] then
+        displayProfile = display["Displays"]["#{displayName}"]
+      end
+    end
     isRetinaDisplay = (displayProfile && displayProfile["Retina"] == true)
 
     system "sips -d profile --deleteColorManagementProperties \"#{tmpfile}\""


### PR DESCRIPTION
Macbook Pro 15inch Retina みたいに GPU を2つ積んだマシンだと、Retina Display のチェック処理で使われてない方の GPU を見てしまうとモニタ情報が取得できなくて落ちる不具合を修正しました。
